### PR TITLE
Interfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,3 +33,7 @@ Third step: Create the `basic` implementation, I wouldn't use any special Go lan
 Creating the concurrency implementation was not as fun as I though on the beggining, it quickly became a complex solution, and I knew from the beggining that It wouldn't be performant.
 
 The only thing that I enjoyed was checking for the goroutines and channels cleanup, as it's something that I always pay special attention (had some weird times with issues on that).
+
+#### entry 04
+
+The interfaces implementation, was a little funnier to develop. I wanted to extract the best interface that I could from Binary Search, ended creating one to update search's boundaries values.

--- a/interfaces/interfaces.go
+++ b/interfaces/interfaces.go
@@ -1,0 +1,43 @@
+package interfaces
+
+// BoundaryUpdater interface define the actions needed to become a Bynary
+// Search Boundary for this implementation, Boundaries are the bootom and upper
+// indexes on each bynary search step.
+type BoundaryUpdater interface {
+	Update(int)
+}
+
+// Boundary is a Custom type from int that will implement BoundaryUpdater.
+type Boundary int
+
+// Updates, updates the Boundary to the given value.
+func (b *Boundary) Update(value int) {
+	*b = Boundary(value)
+}
+
+// chop performs a binary search on the given array looking for the given target.
+//
+// This implementation uses interfaces, interfaces in Go is my favourite
+// feature, more than concurrency. Probably this example is not the best case
+// for interfaces, but I love developing Go with interfaces and wanted to give
+// it a try.
+func chop(target int, array []int) int {
+	lower := Boundary(0)
+	upper := Boundary(len(array))
+
+	for lower < upper {
+		h := int(lower + (upper-lower)/2)
+
+		if array[h] == target {
+			return h
+		}
+
+		if array[h] > target {
+			upper.Update(h)
+		} else {
+			lower.Update(h + 1)
+		}
+	}
+
+	return -1
+}

--- a/interfaces/interfaces_test.go
+++ b/interfaces/interfaces_test.go
@@ -1,0 +1,51 @@
+package interfaces
+
+import (
+	"math/rand"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestChop(t *testing.T) {
+	assert := assert.New(t)
+
+	tests := []struct {
+		Target int
+		Array  []int
+		Result int
+	}{
+		{3, []int{}, -1},
+		{1, []int{1}, 0},
+		{3, []int{1}, -1},
+
+		{1, []int{1, 3, 5}, 0},
+		{3, []int{1, 3, 5}, 1},
+		{5, []int{1, 3, 5}, 2},
+		{0, []int{1, 3, 5}, -1},
+		{2, []int{1, 3, 5}, -1},
+		{4, []int{1, 3, 5}, -1},
+		{6, []int{1, 3, 5}, -1},
+
+		{1, []int{1, 3, 5, 7}, 0},
+		{3, []int{1, 3, 5, 7}, 1},
+		{5, []int{1, 3, 5, 7}, 2},
+		{7, []int{1, 3, 5, 7}, 3},
+		{0, []int{1, 3, 5, 7}, -1},
+		{2, []int{1, 3, 5, 7}, -1},
+		{4, []int{1, 3, 5, 7}, -1},
+		{6, []int{1, 3, 5, 7}, -1},
+		{8, []int{1, 3, 5, 7}, -1},
+	}
+
+	for _, test := range tests {
+		assert.Equal(test.Result, chop(test.Target, test.Array))
+	}
+}
+
+func BenchmarkChop(b *testing.B) {
+	rand.Seed(int64(b.N))
+	for n := 0; n < b.N; n++ {
+		chop(rand.Intn(21), []int{1, 3, 5, 7, 9, 11, 13, 15, 17, 19, 21})
+	}
+}


### PR DESCRIPTION
This PR adds the interface binary search implementation. 

The goal for this implementation was to extract an interface from the Binary Search. Finally ended up creating an interface to update the Binary search's boundaries.

Still is not as fast as the `basic` implementation (as expected). But it's more performant than the concurrent one.